### PR TITLE
Add example SaaS dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,17 @@ python webapp/app.py
 
 Visit `http://localhost:5000` in your browser to see a table of sample NIFTY 50 prices.
 
+### SaaS Dashboard Example
+
+The `dashboard` directory contains a minimal Flask dashboard that integrates the TradingAgents backend. Users upload a CSV of tickers, and the app returns trading signals along with risk judgements.
+
+```bash
+pip install -r requirements.txt
+python dashboard/app.py
+```
+
+Open `http://localhost:5000` in a browser and upload a portfolio file. An API endpoint is available at `/api/analyze` for programmatic use.
+
 
 ## Contributing
 

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -1,0 +1,48 @@
+from flask import Flask, render_template, request, redirect, url_for, jsonify
+import pandas as pd
+from tradingagents.graph.trading_graph import TradingAgentsGraph
+
+app = Flask(__name__)
+
+ta_graph = TradingAgentsGraph(debug=False)
+
+def analyze_symbol(symbol: str, trade_date: str):
+    """Run TradingAgents on a single ticker and return relevant info."""
+    _, decision = ta_graph.propagate(symbol, trade_date)
+    final_state = ta_graph.curr_state
+    risk_judge = final_state["risk_debate_state"]["judge_decision"]
+    investment_plan = final_state["investment_plan"]
+    return {
+        "symbol": symbol,
+        "decision": decision,
+        "risk_judge": risk_judge,
+        "plan": investment_plan,
+    }
+
+@app.route('/')
+def index():
+    return render_template('index.html')
+
+@app.route('/upload', methods=['POST'])
+def upload():
+    file = request.files.get('file')
+    if not file:
+        return redirect(url_for('index'))
+    df = pd.read_csv(file)
+    symbols = df.iloc[:,0].astype(str).tolist()
+    results = []
+    for sym in symbols:
+        results.append(analyze_symbol(sym, '2024-05-10'))
+    return render_template('results.html', results=results)
+
+@app.route('/api/analyze')
+def api_analyze():
+    symbol = request.args.get('symbol')
+    date = request.args.get('date', '2024-05-10')
+    if not symbol:
+        return jsonify({'error': 'symbol is required'}), 400
+    result = analyze_symbol(symbol, date)
+    return jsonify(result)
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/dashboard/templates/index.html
+++ b/dashboard/templates/index.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Trading Dashboard</title>
+</head>
+<body>
+  <h1>Upload Portfolio CSV</h1>
+  <form action="/upload" method="post" enctype="multipart/form-data">
+    <input type="file" name="file" accept=".csv" required>
+    <button type="submit">Analyze</button>
+  </form>
+  <p>CSV should contain a column of symbols. Results are generated with the TradingAgents backend.</p>
+</body>
+</html>

--- a/dashboard/templates/results.html
+++ b/dashboard/templates/results.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Analysis Results</title>
+  <style>
+    table { border-collapse: collapse; width: 100%; }
+    th, td { border: 1px solid #ddd; padding: 8px; }
+    th { background-color: #f2f2f2; }
+  </style>
+</head>
+<body>
+  <h1>Trading Analysis Results</h1>
+  <table>
+    <tr>
+      <th>Symbol</th>
+      <th>Decision</th>
+      <th>Risk Judge</th>
+      <th>Plan</th>
+    </tr>
+    {% for r in results %}
+    <tr>
+      <td>{{ r.symbol }}</td>
+      <td>{{ r.decision }}</td>
+      <td>{{ r.risk_judge }}</td>
+      <td>{{ r.plan }}</td>
+    </tr>
+    {% endfor %}
+  </table>
+  <a href="/">Back</a>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `dashboard` Flask app to demo a basic portfolio upload dashboard
- document usage of the new dashboard in README

## Testing
- `python -m py_compile dashboard/app.py`
- `pip install -r requirements.txt` *(fails: some packages blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6868877f615c832fbf9a36a08f6ef382