### PR TITLE
Fix module import and update dashboard docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ conda activate tradingagents
 Install dependencies:
 ```bash
 pip install -r requirements.txt
+pip install -e .
 ```
 
 ### Required APIs
@@ -211,7 +212,8 @@ The `dashboard` directory contains a minimal Flask dashboard that integrates the
 
 ```bash
 pip install -r requirements.txt
-python dashboard/app.py
+pip install -e .
+python -m dashboard.app
 ```
 
 Open `http://localhost:5000` in a browser and upload a portfolio file. An API endpoint is available at `/api/analyze` for programmatic use.

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -1,5 +1,11 @@
 from flask import Flask, render_template, request, redirect, url_for, jsonify
+import os
+import sys
 import pandas as pd
+
+# Allow running this script directly without installing the package
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
 from tradingagents.graph.trading_graph import TradingAgentsGraph
 
 app = Flask(__name__)


### PR DESCRIPTION
## Summary
- fix dashboard import path so it works without installing
- document installing the package with `pip install -e .`
- instruct running dashboard via module

## Testing
- `pip install -r requirements.txt`
- `python -m dashboard.app` *(fails: OpenAIError: The api_key client option must be set either by passing api_key to the client or by setting the OPENAI_API_KEY environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_68688c534b28832fa3dd4bbbc2fadf02